### PR TITLE
Added support for running on Colab

### DIFF
--- a/opendatasets/utils/network.py
+++ b/opendatasets/utils/network.py
@@ -1,5 +1,6 @@
 import os
 import urllib
+from urllib import request
 import re
 from tqdm import tqdm
 from opendatasets.utils.md5 import check_integrity


### PR DESCRIPTION
This is regarding issue #2 . After merging user will be able to run `import opendatasets` without getting the `Attribution Error.`