### PR TITLE
Addressal of issue #2 by adding support for Colab

### DIFF
--- a/opendatasets/utils/network.py
+++ b/opendatasets/utils/network.py
@@ -6,13 +6,13 @@ from opendatasets.utils.md5 import check_integrity
 
 try:
     urlopen = urllib.request.urlopen
-except Exception:
+except AttributeError:
     # For Python 2.7
     urlopen = urllib.urlopen
 
 try:
     urlretrieve = urllib.request.urlretrieve
-except Exception:
+except AttributeError:
     # For Python 2.7
     urlretrieve = urllib.urlretrieve
 


### PR DESCRIPTION
This is regarding issue #2 . After merging user will be able to run `import opendatasets` without getting the `Attribution Error.`  
The `network.py` file's try except block was written to handle `Exception` whereas Colab was throwing `AttributionError`

[Link to screenshot of Colab giving error on running `import opendatasets`](https://i.imgur.com/fqVOdwq.png)